### PR TITLE
fix: extend data after it was initialized empty

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -147,6 +147,7 @@ exports.list = function(hash) {
  */
 
 var extend = function(original, updates) {
+  original = original || {};
   Object.keys(updates).forEach(function(key) {
     original[key] = updates[key];
   });


### PR DESCRIPTION
I encountered a problem with the extend function, that when I try to fill an empty data record with new data it gives me an error since I can't access a key for a null object. I just added initializing data object if it was null before performing the extend functionality.